### PR TITLE
Improve confirmation box appearance on bigger screens

### DIFF
--- a/src/components/Bekreftelsesboks/styles.ts
+++ b/src/components/Bekreftelsesboks/styles.ts
@@ -11,6 +11,15 @@ export const Boks = styled(AlertStripe)`
     border-radius: 0 !important;
     border-bottom-width: 2px !important;
     width: 100% !important;
+
+    &.alertstripe .alertstripe__ikon {
+        margin-top: auto;
+        margin-bottom: auto;
+    }
+
+    &.alertstripe .alertstripe__tekst {
+        max-width: none;
+    }
 `;
 
 export const InnerContainer = styled.div`
@@ -21,7 +30,8 @@ export const InnerContainer = styled.div`
 
 export const Tekst = styled.div`
     flex: 1 1 auto;
-    max-width: 66%;
+    margin: auto;
+    margin-left: 0;
 `;
 
 export const Undertekst = styled.p`


### PR DESCRIPTION
From this:
<img width="1122" alt="Screenshot 2020-10-21 at 15 04 39" src="https://user-images.githubusercontent.com/2833514/96723337-bf522100-13ae-11eb-958c-0ccd8efd0743.png">

To this:
<img width="1056" alt="Screenshot 2020-10-21 at 15 04 48" src="https://user-images.githubusercontent.com/2833514/96723359-c4af6b80-13ae-11eb-8690-ef6444def36b.png">
